### PR TITLE
[xamu-course] Add course card TODO for section page.

### DIFF
--- a/course/.template.config/template.json
+++ b/course/.template.config/template.json
@@ -11,6 +11,12 @@
         "a80eda4a-1105-44b6-a161-81bf7bac7557"
     ],
     "symbols": {
+        "courseSection": {
+            "type": "parameter",
+            "description": "Folder name where you are creating this course (e.g., \"forms\", \"ios\")",
+            "defaultValue": "forms",
+            "replaces": "{courseSection}"
+        },
         "courseId": {
             "type": "parameter",
             "defaultValue": "abc101",
@@ -67,8 +73,15 @@
         },
         "description": {
             "type": "parameter",
+            "description": "Full course description",
             "defaultValue": "This course is going to be amazing. You will learn all sorts of wonderful things.",
             "replaces": "{description}"
+        },
+        "shortDescription": {
+            "type": "parameter",
+            "description": "Shorter course description for use where space is limited (e.g., course card on section list)",
+            "defaultValue": "You will learn all sorts of wonderful things.",
+            "replaces": "{shortDescription}"
         },
         "objective1": {
             "type": "parameter",

--- a/course/TODO-add-card-to-section-default.md
+++ b/course/TODO-add-card-to-section-default.md
@@ -1,0 +1,12 @@
+    <div class="card card-outline-warning">
+        <div class="card-block">
+            <h4 class="card-title">{title}</h4>
+            <h6 class="card-subtitle mb-2 text-muted">{courseIdUpper}</h6>
+            <p class="card-text">
+            {shortDescription}
+            </p>
+        </div>
+        <div class="card-footer">
+            <a href="/{courseSection}/{courseId}/" class="btn btn-success pull-right">Learn More</a>
+        </div>
+    </div>

--- a/xamu-templates.nuspec
+++ b/xamu-templates.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>XamarinUniversity.ContentTemplates</id>
-    <version>0.8.2</version>
+    <version>0.8.4</version>
     <authors>Adam Patridge</authors>
     <licenseUrl>https://github.com/XamarinUniversity/ContentTemplates/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/XamarinUniversity/ContentTemplates</projectUrl>
@@ -10,6 +10,8 @@
     <description>Templates for creating course content for Xamarin University's self-guided learning portal</description>
     <releaseNotes>
 <![CDATA[
+0.8.4: [xamu-course] Fix short description replacement.
+0.8.3: [xamu-course] Add course card TODO file and required parameters.
 0.8.2: [xamu-objective] Fix fallback {titleShort}.
 0.8.1: Mark more TODO items that require manual intervention.
 0.8.0: Realign common parameter names (breaking change) and correct inaccurate descriptions.


### PR DESCRIPTION
Adding a template page with a course card to copy over to the appropriate section page card list.